### PR TITLE
Add `util` as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "scripts": {
     "test": "nodeunit test"
   },
-  "main": "./sf.js"
+  "main": "./sf.js",
+  "dependencies": {
+    "util": "0.10.3"
+  }
 }


### PR DESCRIPTION
This PR adds [util](https://www.npmjs.com/package/util) package as dependency. For example, when using on a React Native project it fails to load due to the missing `util` package