### PR TITLE
Parse booleans to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "nodeunit": "~0.7.3",
+    "tap": "~10.7.0",
     "timezone-js": "~0.4.3"
   },
   "scripts": {

--- a/sf.js
+++ b/sf.js
@@ -578,6 +578,8 @@ function sf(formatString) {
         result += align(formatDate(val, formatSpec), alignVal);
       } else if (val instanceof Error) {
         result += align(formatError(val, formatSpec), alignVal);
+      } else if (typeof(val) === 'boolean') {
+        result += align(val.toString(), alignVal);
       } else {
         result += align(formatObject(val, formatSpec), alignVal);
       }

--- a/test/stringFormatTest.js
+++ b/test/stringFormatTest.js
@@ -466,6 +466,12 @@ module.exports = {
     test.done();
   },
 
+  'boolean': function(test) {
+    var result = sf("{0}|{1}", false, true);
+    test.equals(result, 'false|true');
+    test.done();
+  },
+
   'unterminated sub': function(test) {
     try {
       sf("a{0", 4);


### PR DESCRIPTION
If the argument is a boolean false, it gets parsed into an empty string. This PR changes that behavior to actually parse it into the string `false`.